### PR TITLE
Minor styles fixes

### DIFF
--- a/src/templates/LastGames.mustache
+++ b/src/templates/LastGames.mustache
@@ -119,7 +119,12 @@
                                         {{/roundTypeTsumo}}
 
                                         {{#roundTypeDraw}}
-                                            Ничья (темпай: {{tempaiPlayers}}).
+                                            {{#tempaiPlayers}}
+                                                Ничья (темпай: {{tempaiPlayers}}).
+                                            {{/tempaiPlayers}}
+                                            {{^tempaiPlayers}}
+                                                Ничья (все нотен).
+                                            {{/tempaiPlayers}}
                                             {{#riichiPlayers}}
                                                 Риичи: {{riichiPlayers}}
                                             {{/riichiPlayers}}

--- a/src/templates/MobileLastGames.mustache
+++ b/src/templates/MobileLastGames.mustache
@@ -26,7 +26,7 @@
         background-color: #555;
         padding: 1px 4px;
         border-radius: 20%;
-        min-width: 30px;
+        min-width: 45px;
         text-align: right;
     }
     .badge.important {

--- a/src/templates/MobileLastGames.mustache
+++ b/src/templates/MobileLastGames.mustache
@@ -162,7 +162,12 @@
                                 {{/roundTypeTsumo}}
 
                                 {{#roundTypeDraw}}
-                                    Ничья (темпай: {{tempaiPlayers}}).
+                                    {{#tempaiPlayers}}
+                                        Ничья (темпай: {{tempaiPlayers}}).
+                                    {{/tempaiPlayers}}
+                                    {{^tempaiPlayers}}
+                                        Ничья (все нотен).
+                                    {{/tempaiPlayers}}
                                     {{#riichiPlayers}}
                                         Риичи: {{riichiPlayers}}
                                     {{/riichiPlayers}}


### PR DESCRIPTION
Было:
![1](https://cloud.githubusercontent.com/assets/475367/24495010/6976edf0-1566-11e7-9c14-4b3ef2cb4c60.png)

Стало:
![2](https://cloud.githubusercontent.com/assets/475367/24495029/704e2fc6-1566-11e7-8047-b28f8b7df727.png)

Было:
![3](https://cloud.githubusercontent.com/assets/475367/24495039/77d2d2ce-1566-11e7-8896-db0b40c8eb6d.png)

Стало:
![4](https://cloud.githubusercontent.com/assets/475367/24495043/7df5661c-1566-11e7-9017-99d5ce5b2c8b.png)



